### PR TITLE
use abi.encode instead of empty string directly

### DIFF
--- a/contracts/MockContract.sol
+++ b/contracts/MockContract.sol
@@ -97,7 +97,7 @@ contract MockContract is MockInterface {
 	mapping(bytes32 => uint) methodIdInvocations;
 
 	MockType fallbackMockType;
-	bytes fallbackExpectation;
+	bytes fallbackExpectation = abi.encode(0);
 	string fallbackRevertMessage;
 	uint invocations;
 	uint resetCount;
@@ -288,7 +288,7 @@ contract MockContract is MockInterface {
 		// Clear list
 		methodIdMocks[SENTINEL_ANY_MOCKS] = SENTINEL_ANY_MOCKS;
 
-		fallbackExpectation = "";
+		fallbackExpectation = abi.encode(0);
 		fallbackMockType = MockType.Return;
 		invocations = 0;
 		resetCount += 1;

--- a/test/MockContract.js
+++ b/test/MockContract.js
@@ -33,6 +33,10 @@ contract('MockContract', function(accounts) {
       await mock.reset()
       result = await complex.acceptAdressUintReturnBool.call("0x0", 10)
       assert.equal(result, false)
+      result = await complex.contract.acceptUintReturnUint.call(7);
+      assert.equal(result, 0)
+      result = await complex.contract.acceptUintReturnAddress.call(7);
+      assert.equal(result, 0x0)
 
       // Check convenience methods
       await mock.givenAnyReturnBool(true)


### PR DESCRIPTION
In case a function is not mocked, we return a fallback value which by default is empty bytes (0x)
Web3 doesn't accept 0x as a valid return type for functions returning strings anymore. This is why CI on master is currently failing.

Encoding the fallback value as abi.encode(0) seems to do the trick.