### PR TITLE
Fix mocking functions that return address

### DIFF
--- a/contracts/ExampleContractUnderTest.sol
+++ b/contracts/ExampleContractUnderTest.sol
@@ -15,4 +15,9 @@ contract ExampleContractUnderTest {
         complexInterface.acceptUintReturnUintView(1);
         return true;
     }
+
+    function callMethodThatReturnsAddress() public returns (address) {
+        address foo = complexInterface.acceptUintReturnAddress(1);
+        return foo;
+    }
 }

--- a/contracts/MockContract.sol
+++ b/contracts/MockContract.sol
@@ -141,7 +141,7 @@ contract MockContract is MockInterface {
 	}
 
 	function givenAnyReturnAddress(address response) external {
-		_givenAnyReturn(addressToBytes(response));
+		_givenAnyReturn(uintToBytes(uint(response)));
 	}
 
 	function givenAnyRevert() external {
@@ -178,7 +178,7 @@ contract MockContract is MockInterface {
 	}
 
 	function givenCalldataReturnAddress(bytes calldata call, address response) external {
-		_givenCalldataReturn(call, addressToBytes(response));
+		_givenCalldataReturn(call, uintToBytes(uint(response)));
 	}
 
 	function _givenMethodReturn(bytes memory call, bytes memory response) private {
@@ -202,7 +202,7 @@ contract MockContract is MockInterface {
 	}
 
 	function givenMethodReturnAddress(bytes calldata call, address response) external {
-		_givenMethodReturn(call, addressToBytes(response));
+		_givenMethodReturn(call, uintToBytes(uint(response)));
 	}
 
 	function givenCalldataRevert(bytes calldata call) external {
@@ -310,15 +310,6 @@ contract MockContract is MockInterface {
 			out |= bytes4(b[i] & 0xFF) >> (i * 8);
 		}
 		return out;
-	}
-
-	function addressToBytes(address a) private pure returns (bytes memory b){
-		assembly {
-			let m := mload(0x40)
-			mstore(add(m, 20), xor(0x140000000000000000000000000000000000000000, a))
-			mstore(0x40, add(m, 52))
-			b := m
-		}
 	}
 
 	function uintToBytes(uint256 x) private pure returns (bytes memory b) {

--- a/test/MockContract.js
+++ b/test/MockContract.js
@@ -169,9 +169,8 @@ contract('MockContract', function(accounts) {
       assert.equal(8, result)
     });
       
-    it("should call method 3 times and return constant in 1 transaction", async function() {
+    it("should allow contract under test to call mocked method 3 times in 1 transaction", async function() {
       const mock = await MockContract.new();
-      const complex = ComplexInterface.at(mock.address)
       const exampleContract = await ExampleContractUnderTest.new(mock.address);
 
       mock.givenAnyReturnUint(1)
@@ -295,6 +294,17 @@ contract('MockContract', function(accounts) {
       await mock.givenMethodReturnAddress(methodId, accounts[0])
       result = await complex.contract.acceptUintReturnAddress.call(0);
       assert.equal(result, accounts[0])
+    });
+
+    it("should mock method returning an address which can be used in `contract under test`", async function() {
+      const mock = await MockContract.new();
+      const complex = ComplexInterface.at(mock.address)
+      const exampleContract = await ExampleContractUnderTest.new(mock.address);
+      
+      const methodId = await complex.contract.acceptUintReturnAddress.getData(0);
+      await mock.givenMethodReturnAddress(methodId, accounts[0]);
+      
+      await exampleContract.callMethodThatReturnsAddress();
     });
   });
 


### PR DESCRIPTION
The added unit test currently reverts the transaction, because the way we convert `address` to `bytes` doesn't seem to be valid. 
This surfaces if a contract under test calls a mocked method that returns an address (originally reported from a failing test here: https://github.com/okwme/safe-contracts/blob/billy/arbitrage-module/test/arbitrageModule.js#L75).
Note, that this issue doesn't happen when the mocked method is called directly from JS (however mocking only makes sense when mocked method is called from another smart contract).

Instead of using the complicated way of converting address into bytes (originally taken from: https://ethereum.stackexchange.com/questions/884/how-to-convert-an-address-to-bytes-in-solidity), it seems to be fine to convert the `address` into `uint` and use the existing `uintToBytes` method.