### PR TITLE
Make contract return nullish values without explicit mocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 build/
 node_modules/
 package-lock.json

--- a/contracts/ExampleContractUnderTest.sol
+++ b/contracts/ExampleContractUnderTest.sol
@@ -20,4 +20,8 @@ contract ExampleContractUnderTest {
         address foo = complexInterface.acceptUintReturnAddress(1);
         return foo;
     }
+
+    function callMethodThatReturnsBool() public returns (bool) {
+        return complexInterface.acceptUintReturnBool(1);
+    }
 }

--- a/contracts/MockContract.sol
+++ b/contracts/MockContract.sol
@@ -82,6 +82,7 @@ contract MockContract is MockInterface {
 	bytes public constant MOCKS_LIST_END = "0xff";
 	bytes32 public constant MOCKS_LIST_END_HASH = keccak256(MOCKS_LIST_END);
 	bytes4 public constant SENTINEL_ANY_MOCKS = hex"01";
+    bytes public constant DEFAULT_FALLBACK_VALUE = abi.encode(false);
 
 	// A linked list allows easy iteration and inclusion checks
 	mapping(bytes32 => bytes) calldataMocks;
@@ -97,7 +98,7 @@ contract MockContract is MockInterface {
 	mapping(bytes32 => uint) methodIdInvocations;
 
 	MockType fallbackMockType;
-	bytes fallbackExpectation = abi.encode(false);
+	bytes fallbackExpectation = DEFAULT_FALLBACK_VALUE;
 	string fallbackRevertMessage;
 	uint invocations;
 	uint resetCount;
@@ -288,7 +289,7 @@ contract MockContract is MockInterface {
 		// Clear list
 		methodIdMocks[SENTINEL_ANY_MOCKS] = SENTINEL_ANY_MOCKS;
 
-		fallbackExpectation = abi.encode(false);
+		fallbackExpectation = DEFAULT_FALLBACK_VALUE;
 		fallbackMockType = MockType.Return;
 		invocations = 0;
 		resetCount += 1;

--- a/contracts/MockContract.sol
+++ b/contracts/MockContract.sol
@@ -82,7 +82,7 @@ contract MockContract is MockInterface {
 	bytes public constant MOCKS_LIST_END = "0xff";
 	bytes32 public constant MOCKS_LIST_END_HASH = keccak256(MOCKS_LIST_END);
 	bytes4 public constant SENTINEL_ANY_MOCKS = hex"01";
-    bytes public constant DEFAULT_FALLBACK_VALUE = abi.encode(false);
+	bytes public constant DEFAULT_FALLBACK_VALUE = abi.encode(false);
 
 	// A linked list allows easy iteration and inclusion checks
 	mapping(bytes32 => bytes) calldataMocks;

--- a/contracts/MockContract.sol
+++ b/contracts/MockContract.sol
@@ -97,7 +97,7 @@ contract MockContract is MockInterface {
 	mapping(bytes32 => uint) methodIdInvocations;
 
 	MockType fallbackMockType;
-	bytes fallbackExpectation;
+	bytes fallbackExpectation = abi.encode(false);
 	string fallbackRevertMessage;
 	uint invocations;
 	uint resetCount;
@@ -288,7 +288,7 @@ contract MockContract is MockInterface {
 		// Clear list
 		methodIdMocks[SENTINEL_ANY_MOCKS] = SENTINEL_ANY_MOCKS;
 
-		fallbackExpectation = "";
+		fallbackExpectation = abi.encode(false);
 		fallbackMockType = MockType.Return;
 		invocations = 0;
 		resetCount += 1;

--- a/test/MockContract.js
+++ b/test/MockContract.js
@@ -4,6 +4,8 @@ const MockContract = artifacts.require("./MockContract.sol")
 const ComplexInterface = artifacts.require("./ComplexInterface.sol")
 const ExampleContractUnderTest = artifacts.require("./ExampleContractUnderTest.sol")
 
+const ZERO = "0x0000000000000000000000000000000000000000000000000000000000000000"
+
 contract('MockContract', function(accounts) {
 
   describe("cleanState", function() {
@@ -12,6 +14,14 @@ contract('MockContract', function(accounts) {
       const complex = ComplexInterface.at(mock.address)
 
       result = await complex.acceptAdressUintReturnBool.call("0x0", 10);
+      assert.equal(result, false)
+    });
+
+    it("should return null if not mocked when called by contract under test", async function() {
+      const mock = await MockContract.new()
+      const exampleContract = await ExampleContractUnderTest.new(mock.address);
+
+      result = await exampleContract.callMethodThatReturnsBool.call();
       assert.equal(result, false)
     });
   });
@@ -414,7 +424,7 @@ contract('MockContract', function(accounts) {
       // Transactions should be successful
       const request = complex.acceptUintReturnString.request([42])
       response = await utils.getRPCResult(request.params);
-      assert.equal(response.result, "0x")
+      assert.equal(response.result, ZERO)
     }
 
     it("all specific mocks should be prioritized over return any mock", async function() {
@@ -424,7 +434,7 @@ contract('MockContract', function(accounts) {
       // No mock set
       const request = complex.acceptUintReturnString.request([42])
       response = await utils.getRPCResult(request.params);
-      assert.equal(response.result, "0x")
+      assert.equal(response.result, ZERO)
 
       // Fallback mock set
       await mock.givenAnyReturn(abi.rawEncode(['string'], ["fallback"]).toString())
@@ -447,7 +457,7 @@ contract('MockContract', function(accounts) {
       // No mock set
       const request = complex.acceptUintReturnString.request([42])
       response = await utils.getRPCResult(request.params);
-      assert.equal(response.result, "0x")
+      assert.equal(response.result, ZERO)
 
       const encoded = await complex.contract.acceptUintReturnString.getData(42)
 
@@ -473,7 +483,7 @@ contract('MockContract', function(accounts) {
       // No mock set
       const request = complex.acceptUintReturnString.request([42])
       response = await utils.getRPCResult(request.params);
-      assert.equal(response.result, "0x")
+      assert.equal(response.result, ZERO)
 
       // Fallback mock set
       await mock.givenAnyReturn(abi.rawEncode(['string'], ["fallback"]).toString())

--- a/test/MockContract.js
+++ b/test/MockContract.js
@@ -4,8 +4,6 @@ const MockContract = artifacts.require("./MockContract.sol")
 const ComplexInterface = artifacts.require("./ComplexInterface.sol")
 const ExampleContractUnderTest = artifacts.require("./ExampleContractUnderTest.sol")
 
-const ZERO = "0x0000000000000000000000000000000000000000000000000000000000000000"
-
 contract('MockContract', function(accounts) {
 
   describe("cleanState", function() {
@@ -422,9 +420,8 @@ contract('MockContract', function(accounts) {
       // Check that we can reset revert
       await mock.reset()
       // Transactions should be successful
-      const request = complex.acceptUintReturnString.request([42])
-      response = await utils.getRPCResult(request.params);
-      assert.equal(response.result, ZERO)
+      const response = await complex.acceptUintReturnString.call(42)
+      assert.equal(response, "")
     }
 
     it("all specific mocks should be prioritized over return any mock", async function() {
@@ -432,14 +429,12 @@ contract('MockContract', function(accounts) {
       const complex = ComplexInterface.at(mock.address)
 
       // No mock set
-      const request = complex.acceptUintReturnString.request([42])
-      response = await utils.getRPCResult(request.params);
-      assert.equal(response.result, ZERO)
+      const response = await complex.acceptUintReturnString.call(42)
+      assert.equal(response, "")
 
       // Fallback mock set
       await mock.givenAnyReturn(abi.rawEncode(['string'], ["fallback"]).toString())
-      response = await utils.getRPCResult(request.params);
-      result = await complex.acceptUintReturnString.call(42);
+      let result = await complex.acceptUintReturnString.call(42)
       assert.equal(result, "fallback")
 
       // MethodId mock set
@@ -455,9 +450,8 @@ contract('MockContract', function(accounts) {
       const complex = ComplexInterface.at(mock.address)
 
       // No mock set
-      const request = complex.acceptUintReturnString.request([42])
-      response = await utils.getRPCResult(request.params);
-      assert.equal(response.result, ZERO)
+      const response = await complex.acceptUintReturnString.call(42)
+      assert.equal(response, "")
 
       const encoded = await complex.contract.acceptUintReturnString.getData(42)
 
@@ -481,9 +475,8 @@ contract('MockContract', function(accounts) {
       const complex = ComplexInterface.at(mock.address)
 
       // No mock set
-      const request = complex.acceptUintReturnString.request([42])
-      response = await utils.getRPCResult(request.params);
-      assert.equal(response.result, ZERO)
+      const response = await complex.acceptUintReturnString.call(42)
+      assert.equal(response, "")
 
       // Fallback mock set
       await mock.givenAnyReturn(abi.rawEncode(['string'], ["fallback"]).toString())

--- a/test/utils.js
+++ b/test/utils.js
@@ -35,22 +35,9 @@ async function getErrorMessage(to, value, data, from) {
     return abi.rawDecode(["string"], returnBuffer.slice(4))[0]
 }
 
-// Only for tests, as its fixed to default web3: http://localhost:8545
-async function getRPCResult(params) {
-    return new Promise((resolve, reject) => {
-        web3.currentProvider.sendAsync({
-            method: "eth_call",
-            params,
-            jsonrpc: "2.0",
-            id: new Date().getTime()
-        }, (e, result) => (e ? reject(e) : resolve(result)))
-    })
-}
-
 Object.assign(exports, {
     assertRejects,
     getErrorMessage,
     assertOutOfGas,
     assertRevert,
-    getRPCResult
 })


### PR DESCRIPTION
As the added unit test demonstrates, we are at the moment not able to invoke a method on the mocked contract from another smart contract (ContractUnderTest) without previously setting an expectation via e.g. `givenAnyReturnBool(false)`.

Since fallbackExpectation was set to empty, we would run into the following error:

```
Error: VM Exception while processing transaction: revert
      at Object.InvalidResponse (node_modules/truffle/build/webpack:/~/web3/lib/web3/errors.js:38:1)
      at node_modules/truffle/build/webpack:/~/web3/lib/web3/requestmanager.js:86:1
      at node_modules/truffle/build/webpack:/packages/truffle-provider/wrapper.js:134:1
      at XMLHttpRequest.request.onreadystatechange (node_modules/truffle/build/webpack:/~/web3/lib/web3/httpprovider.js:128:1)
      at XMLHttpRequestEventTarget.dispatchEvent (node_modules/truffle/build/webpack:/~/xhr2/lib/xhr2.js:64:1)
      at XMLHttpRequest._setReadyState (node_modules/truffle/build/webpack:/~/xhr2/lib/xhr2.js:354:1)
      at XMLHttpRequest._onHttpResponseEnd (node_modules/truffle/build/webpack:/~/xhr2/lib/xhr2.js:509:1)
      at IncomingMessage.<anonymous> (node_modules/truffle/build/webpack:/~/xhr2/lib/xhr2.js:469:1)
      at endReadableNT (_stream_readable.js:1125:12)
      at process._tickCallback (internal/process/next_tick.js:63:19)
```

This PR makes it that our fallback value is not empty but instead the abi encoding of false (`0x0000000000000000000000000000000000000000000000000000000000000000`).

This way we won't need to call

```
await mock.givenAnyReturn(false)
```

but instead can use the mock right after initialization and get nullish values.

### Test Plan

Added unit test.